### PR TITLE
open firewalld ports

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -25,6 +25,14 @@
       - python3-cryptography
       - kubectl
       - bash-completion
+  - name: Open Ports in firewalld
+    ansible.posix.firewalld:
+      port: "{{ item }}"
+      permanent: true
+      state: enabled
+    loop:
+      - 8000/tcp
+      - 9000/tcp
   - name: Create a podman secret for the self signed certificate
     block:
     - name: Create a scrtach directory

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,3 @@
 collections:
 - community.general
+- ansible.posix


### PR DESCRIPTION
In my setup it seems to be working without the rules, but it might be needed somewhere else?

Or does Podman bypass the rules due to the separate network that is being used?