### PR TITLE
playbook.yml: do not use special characters for mysql root password

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -89,7 +89,7 @@
     block:
     - name: Create random string and save it in root_password
       ansible.builtin.set_fact:
-        root_password: "{{ lookup('community.general.random_string') }}"
+        root_password: "{{ lookup('community.general.random_string', special=false, length=20) }}"
 
     - name: Create the kube secret
       ansible.builtin.shell: |


### PR DESCRIPTION
As soon as there is a " in the password, Ansible errors out due to quoting issues. And a " is allowed by default:
- <https://docs.ansible.com/ansible/latest/collections/community/general/random_string_lookup.html#parameter-special>
- <https://docs.python.org/3/library/string.html#string.punctuation>