### PR TITLE
use ansible service_facts to check for firewalld

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,2 @@
 skip_list:
 - package-latest
-- no-handler

--- a/playbook.yml
+++ b/playbook.yml
@@ -31,12 +31,8 @@
       - kubectl
       - bash-completion
 
-  - name: Check if firewalld is installed
-    ansible.builtin.package:
-      name: firewalld
-      state: present
-    check_mode: true
-    register: firewalld_exists
+  - name: Populate service facts
+    ansible.builtin.service_facts:
 
   - name: Open Ports in firewalld
     ansible.posix.firewalld:
@@ -46,7 +42,9 @@
     loop:
     - 8000/tcp
     - 9000/tcp
-    when: not firewalld_exists.changed
+    when:
+    - services['firewalld.service'] is defined
+    - services['firewalld.service']['state'] == 'running'
 
   - name: Create a podman secret for the self signed certificate
     block:


### PR DESCRIPTION
Worked in my tests with both firewalld uninstalled and running:

```
TASK [Populate service facts] **************************************************
ok: [quadlet-nginx-envoy-tls]

TASK [Open Ports in firewalld] *************************************************
changed: [quadlet-nginx-envoy-tls] => (item=8080/tcp)
changed: [quadlet-nginx-envoy-tls] => (item=8443/tcp)
changed: [quadlet-nginx-envoy-tls] => (item=9000/tcp)
```

```
TASK [Populate service facts] **************************************************
ok: [quadlet-nginx-envoy-tls]

TASK [Open Ports in firewalld] *************************************************
skipping: [quadlet-nginx-envoy-tls] => (item=8080/tcp) 
skipping: [quadlet-nginx-envoy-tls] => (item=8443/tcp) 
skipping: [quadlet-nginx-envoy-tls] => (item=9000/tcp) 
skipping: [quadlet-nginx-envoy-tls]
```