### PR TITLE
use the Ansible podman_secret module to make secret generation idempotent

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -76,13 +76,29 @@
         privatekey_path: /opt/quadlet-demo/certificate.key
         provider: selfsigned
 
-    - name: Create the podman secret for the envoy certificates
-      ansible.builtin.shell: |
-        kubectl create secret generic --from-file=certificate.key --from-file=certificate.pem envoy-certificates --dry-run=client -o yaml | podman kube play -
-      args:
-        chdir: /opt/quadlet-demo/
-      register: secret_created
-      changed_when: secret_created.rc == 0
+    - name: Slurp certificate pem file
+      ansible.builtin.slurp:
+        src: '/opt/quadlet-demo/certificate.pem'
+      register: slurp_certificate_pem
+
+    - name: Slurp certificate key file
+      ansible.builtin.slurp:
+        src: '/opt/quadlet-demo/certificate.key'
+      register: slurp_certificate_key
+
+    - name: Create the podman secret
+      containers.podman.podman_secret:
+        name: envoy-certificates
+        state: present
+        skip_existing: true
+        data: |
+          apiVersion: v1
+          data:
+            certificate.key: {{ slurp_certificate_key['content'] }}
+            certificate.pem: {{ slurp_certificate_pem['content'] }}
+          kind: Secret
+          metadata:
+            name: envoy-certificates
 
   - name: Create the secrets for the mysql server
     block:

--- a/playbook.yml
+++ b/playbook.yml
@@ -76,7 +76,7 @@
         privatekey_path: /opt/quadlet-demo/certificate.key
         provider: selfsigned
 
-    - name: Create the podman secret
+    - name: Create the podman secret for the envoy certificates
       ansible.builtin.shell: |
         kubectl create secret generic --from-file=certificate.key --from-file=certificate.pem envoy-certificates --dry-run=client -o yaml | podman kube play -
       args:
@@ -90,13 +90,13 @@
       ansible.builtin.set_fact:
         root_password: "{{ lookup('community.general.random_string', special=false, length=20) }}"
 
-    - name: Create the kube secret
+    - name: Create the kube secret for the mysql root password
       ansible.builtin.shell: |
         kubectl create secret generic --from-literal=password="{{ root_password }}" mysql-root-password-kube --dry-run=client -o yaml | podman kube play -
       register: secret_created
       changed_when: secret_created.rc == 0
 
-    - name: Create the podman secret
+    - name: Create the podman secret for the mysql root password
       ansible.builtin.shell: |
         echo -n "{{ root_password }}" | podman secret create mysql-root-password-container -
       register: secret_created

--- a/playbook.yml
+++ b/playbook.yml
@@ -104,10 +104,11 @@
             name: mysql-root-password-kube
 
     - name: Create the podman secret for the mysql root password
-      ansible.builtin.shell: |
-        echo -n "{{ root_password }}" | podman secret create mysql-root-password-container -
-      register: secret_created
-      changed_when: secret_created.rc == 0
+      containers.podman.podman_secret:
+        name: mysql-root-password-container
+        state: present
+        skip_existing: true
+        data: "{{ root_password }}"
 
   - name: Create the Quadlet directory
     ansible.builtin.file:

--- a/playbook.yml
+++ b/playbook.yml
@@ -11,24 +11,11 @@
     retries: 5
     until: result is success
 
-  - name: Get machine architecture and save it as a fact
-    ansible.builtin.set_fact:
-      repository_arch: "{{ ansible_architecture if ansible_architecture == 'x86_64' else 'aarch64' }}"
-
-  - name: Add the Kubernetes YUM repo
-    ansible.builtin.yum_repository:
-      name: Kubernetes
-      description: Kubernetes
-      baseurl: "https://packages.cloud.google.com/yum/repos/kubernetes-el7-{{ repository_arch }}"
-      gpgcheck: true
-      gpgkey: https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-
   - name: Install packages
     ansible.builtin.package:
       name:
       - podman
       - python3-cryptography
-      - kubectl
       - bash-completion
 
   - name: Populate service facts

--- a/playbook.yml
+++ b/playbook.yml
@@ -91,10 +91,17 @@
         root_password: "{{ lookup('community.general.random_string', special=false, length=20) }}"
 
     - name: Create the kube secret for the mysql root password
-      ansible.builtin.shell: |
-        kubectl create secret generic --from-literal=password="{{ root_password }}" mysql-root-password-kube --dry-run=client -o yaml | podman kube play -
-      register: secret_created
-      changed_when: secret_created.rc == 0
+      containers.podman.podman_secret:
+        name: mysql-root-password-kube
+        state: present
+        skip_existing: true
+        data: |
+          apiVersion: v1
+          data:
+            password: "{{ root_password | b64encode }}"
+          kind: Secret
+          metadata:
+            name: mysql-root-password-kube
 
     - name: Create the podman secret for the mysql root password
       ansible.builtin.shell: |

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,3 +2,4 @@ collections:
 - community.general
 - community.crypto
 - ansible.posix
+- containers.podman


### PR DESCRIPTION
successor of #19 and #23

It took me a while, but I think now I got it:

Podman secrets contain only a value. They get an ID and and stored in `/var/lib/containers/storage/secrets/filedriver` as base64 encoded strings.

```
[root@quadlet-demo ~]# echo "Hello" | podman secret create mysecret -
18ed3fa112e5db63364c8c0c4
[root@quadlet-demo ~]# podman secret inspect mysecret
[
    {
        "ID": "18ed3fa112e5db63364c8c0c4",
        "CreatedAt": "2023-03-21T15:34:13.800126852Z",
        "UpdatedAt": "2023-03-21T15:34:13.800126852Z",
        "Spec": {
            "Name": "mysecret",
            "Driver": {
                "Name": "file",
                "Options": {
                    "path": "/var/lib/containers/storage/secrets/filedriver"
                }
            },
            "Labels": {}
        }
    }
]
[root@quadlet-demo ~]# cat /var/lib/containers/storage/secrets/filedriver/secretsdata.json 
{
  "18ed3fa112e5db63364c8c0c4": "SGVsbG8K"
}[root@quadlet-demo ~]# echo SGVsbG8K|base64 -d
Hello
[root@quadlet-demo ~]#
```

Secrets created by `kubectl ... | podman play kube` contain also only a value, but in this case it is the whole kubernetes secret YAML:

```
[root@quadlet-demo ~]# kubectl create secret generic --from-literal=password=hello mykubesecret --dry-run=client -o yaml | podman kube play -
[root@quadlet-demo ~]# podman secret inspect mykubesecret
[
    {
        "ID": "6979ab3f9d11be64bac6ccc36",
        "CreatedAt": "2023-03-21T15:35:49.757097061Z",
        "UpdatedAt": "2023-03-21T15:35:49.757097061Z",
        "Spec": {
            "Name": "mykubesecret",
            "Driver": {
                "Name": "file",
                "Options": {
                    "path": "/var/lib/containers/storage/secrets/filedriver"
                }
            },
            "Labels": {}
        }
    }
]
[root@quadlet-demo ~]# cat /var/lib/containers/storage/secrets/filedriver/secretsdata.json 
{
  "6979ab3f9d11be64bac6ccc36": "YXBpVmVyc2lvbjogdjEKZGF0YToKICBwYXNzd29yZDogYUdWc2JHOD0Ka2luZDogU2VjcmV0Cm1ldGFkYXRhOgogIGNyZWF0aW9uVGltZXN0YW1wOiBudWxsCiAgbmFtZTogbXlrdWJlc2VjcmV0Cg=="
}[root@quadlet-demo ~]# echo YXBpVmVyc2lvbjogdjEKZGF0YToKICBwYXNzd29yZDogYUdWc2JHOD0Ka2luZDogU2VjcmV0Cm1ldGFkYXRhOgogIGNyZWF0aW9uVGltZXN0YW1wOiBudWxsCiAgbmFtZTogbXlrdWJlc2VjcmV0Cg== | base64 -d
apiVersion: v1
data:
  password: aGVsbG8=
kind: Secret
metadata:
  creationTimestamp: null
  name: mykubesecret
[root@quadlet-demo ~]#
```

So, the trick for generating kube-style secrets using podman secret create or the Ansible module is to specify the whole YAML file, just like you would do for Kubernetes.

This avoids the shell module calls and the hassle to get this idempotent.